### PR TITLE
feat: add hotreload on dockerfile

### DIFF
--- a/.air.conf
+++ b/.air.conf
@@ -1,0 +1,42 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/fiap-tech-fast-food"
+  cmd = "go build -o ./tmp/fiap-tech-fast-food ./cmd/go-command.go"
+  delay = 0
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .vscode
 
 internal/adapter/infra/config/configs.yaml
+
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,10 @@ tests:
 
 serve-swagger:
 	@swag init -g cmd/go-command.go --parseDependency
+
+init-config-local:
+	if [ ! -f "./internal/adapter/infra/config/configs.yaml" ]; then cp ./internal/adapter/infra/config/configs.yaml.sample ./internal/adapter/infra/config/configs.yaml; fi
+
+
+start-local: init-config-local
+	docker-compose -f docker/docker-compose.yaml up

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -10,6 +10,16 @@ services:
     networks:
       - mongo-compose-network
 
+  fiap-tech-fast-food:
+    image: cosmtrek/air
+    working_dir: /project
+    ports:
+      - 8080:8080
+    volumes:
+      - ./../:/project
+    networks:
+      - mongo-compose-network
+
 networks: 
     mongo-compose-network:
       driver: bridge

--- a/internal/adapter/infra/config/configs.yaml.sample
+++ b/internal/adapter/infra/config/configs.yaml.sample
@@ -1,5 +1,6 @@
 mongodb:
-  host: "172.25.0.2"
+  # use docker-nameservice or use the mongodb ip host
+  host: mongoservice
   port: "27017"
   database: "db"
 api:


### PR DESCRIPTION
- Criado uma nova action no makeFile
 ```
 make start-local
 ```

Este comando verifica se o arquivo de config está criado, caso não esteja ele cria a partir do sample; em seguida o container irá iniciar fazendo o build do projeto e criando o link entre os containers de mongo e service.
O containter do service está em utilizando uma imagem que possibilita hot-reload, então a qualquer mudança no código no watch do serviço o build é reexecutado e a api é reiniciada.

Estas configs podem ser verificadas e ajustas nos arquivos:

- `Makefile`
- `.air.conf`
- `/docker/docker-compose.yaml`