### PR TITLE
Fix customer creation

### DIFF
--- a/internal/adapter/driven/repository/mongodb/databaseAdapter.go
+++ b/internal/adapter/driven/repository/mongodb/databaseAdapter.go
@@ -3,6 +3,7 @@ package mongodb
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	coreErrors "github.com/hcsouza/fiap-tech-fast-food/internal/core/errors"
@@ -81,12 +82,8 @@ func (ad *mongoAdapter[T]) Save(data interface{}) (interface{}, error) {
 
 	res, err := ad.collection.InsertOne(ctx, data)
 	if err != nil {
-		if writeException, ok := err.(mongo.WriteException); ok {
-			for _, writeError := range writeException.WriteErrors {
-				if writeError.Code == MongoDuplicateKeyErrorCode {
-					return nil, coreErrors.ErrDuplicatedKey
-				}
-			}
+		if strings.Contains(err.Error(), "duplicate key error") {
+			return nil, coreErrors.ErrDuplicatedKey
 		}
 		return nil, err
 	}

--- a/internal/adapter/driver/api/v1/handlers/customerHandler.go
+++ b/internal/adapter/driver/api/v1/handlers/customerHandler.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-playground/validator/v10"
 	"github.com/hcsouza/fiap-tech-fast-food/internal/core/domain"
+	coreErrors "github.com/hcsouza/fiap-tech-fast-food/internal/core/errors"
 	"github.com/hcsouza/fiap-tech-fast-food/internal/core/useCases/customer"
 	"github.com/hcsouza/fiap-tech-fast-food/internal/core/valueObject/cpf"
 )
@@ -63,6 +64,12 @@ func (handler *customerHandler) CreateCustomerHandler(ctx *gin.Context) {
 	}
 
 	customer, err := handler.interactor.CreateCustomer(ctx.Request.Context(), createRequest)
+
+	if errors.Is(err, coreErrors.ErrDuplicatedKey) {
+		ctx.JSON(http.StatusConflict, gin.H{"error": "customer already exists"})
+		return
+	}
+
 	if err != nil {
 		ctx.JSON(http.StatusInternalServerError, err)
 		return

--- a/internal/adapter/driver/api/v1/handlers/customerHandler.go
+++ b/internal/adapter/driver/api/v1/handlers/customerHandler.go
@@ -71,7 +71,7 @@ func (handler *customerHandler) CreateCustomerHandler(ctx *gin.Context) {
 	}
 
 	if err != nil {
-		ctx.JSON(http.StatusInternalServerError, err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 	ctx.JSON(http.StatusCreated, customer)

--- a/internal/core/errors/errors.go
+++ b/internal/core/errors/errors.go
@@ -1,0 +1,5 @@
+package errors
+
+import "errors"
+
+var ErrDuplicatedKey = errors.New("duplicate key error on collection")


### PR DESCRIPTION
Guard clause na criação de customer, quando informado um body com cpf já cadastrado.
- databaseAdapter verifica o mongoErrorStatus code e devolve um Error padrão definido dentro de "core/errors"