### PR TITLE
fix: add swagger missing payment received status

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -193,7 +193,7 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "STARTED, WAITING_PAYMENT, RECEIVED, PREPARING, READY or COMPLETED",
+                        "description": "STARTED, WAITING_PAYMENT, PAYMENT_RECEIVED, RECEIVED, PREPARING, READY or COMPLETED",
                         "name": "status",
                         "in": "path",
                         "required": true
@@ -296,7 +296,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "string",
-                        "description": "STARTED, WAITING_PAYMENT, RECEIVED, PREPARING, READY or COMPLETED",
+                        "description": "STARTED, WAITING_PAYMENT, PAYMENT_RECEIVED, RECEIVED, PREPARING, READY or COMPLETED",
                         "name": "status",
                         "in": "path",
                         "required": true

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -187,7 +187,7 @@
                 "parameters": [
                     {
                         "type": "string",
-                        "description": "STARTED, WAITING_PAYMENT, RECEIVED, PREPARING, READY or COMPLETED",
+                        "description": "STARTED, WAITING_PAYMENT, PAYMENT_RECEIVED, RECEIVED, PREPARING, READY or COMPLETED",
                         "name": "status",
                         "in": "path",
                         "required": true
@@ -290,7 +290,7 @@
                     },
                     {
                         "type": "string",
-                        "description": "STARTED, WAITING_PAYMENT, RECEIVED, PREPARING, READY or COMPLETED",
+                        "description": "STARTED, WAITING_PAYMENT, PAYMENT_RECEIVED, RECEIVED, PREPARING, READY or COMPLETED",
                         "name": "status",
                         "in": "path",
                         "required": true

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -246,7 +246,8 @@ paths:
         name: id
         required: true
         type: string
-      - description: STARTED, WAITING_PAYMENT, RECEIVED, PREPARING, READY or COMPLETED
+      - description: STARTED, WAITING_PAYMENT, PAYMENT_RECEIVED, RECEIVED, PREPARING,
+          READY or COMPLETED
         in: path
         name: status
         required: true
@@ -305,7 +306,8 @@ paths:
       - application/json
       description: Get all orders by status
       parameters:
-      - description: STARTED, WAITING_PAYMENT, RECEIVED, PREPARING, READY or COMPLETED
+      - description: STARTED, WAITING_PAYMENT, PAYMENT_RECEIVED, RECEIVED, PREPARING,
+          READY or COMPLETED
         in: path
         name: status
         required: true

--- a/internal/adapter/driver/api/v1/handlers/orderHandler.go
+++ b/internal/adapter/driver/api/v1/handlers/orderHandler.go
@@ -65,7 +65,7 @@ func (handler *orderHandler) FindByIdHandler(c *gin.Context) {
 // @Summary Get all orders by status
 // @Description Get all orders by status
 // @Tags Order Routes
-// @Param        status   path      string  true  "STARTED, WAITING_PAYMENT, RECEIVED, PREPARING, READY or COMPLETED"
+// @Param        status   path      string  true  "STARTED, WAITING_PAYMENT, PAYMENT_RECEIVED, RECEIVED, PREPARING, READY or COMPLETED"
 // @Accept  json
 // @Produce  json
 // @Success 200 {array} domain.Order{}
@@ -240,7 +240,7 @@ func (handler orderHandler) ConfirmPaymentOrderHandler(c *gin.Context) {
 // @Description Update order status
 // @Tags Order Routes
 // @Param        id   path      string  true  "Order ID"
-// @Param        status   path      string  true  "STARTED, WAITING_PAYMENT, RECEIVED, PREPARING, READY or COMPLETED"
+// @Param        status   path      string  true  "STARTED, WAITING_PAYMENT, PAYMENT_RECEIVED, RECEIVED, PREPARING, READY or COMPLETED"
 // @Accept  json
 // @Produce  json
 // @Success 204


### PR DESCRIPTION
## Descrição 🗒️
### Fix
- Adicionado status _PAYMENT_RECEIVED_ nos endpoints referentes a consulta e atualização de pedidos por status.
---

Get all orders by status

<img width="1093" alt="image" src="https://github.com/hcsouza/fiap-tech-fast-food/assets/19635428/e6e69dfe-b583-41e7-a316-4d2cfce360b5">

---

Update order status

<img width="981" alt="image" src="https://github.com/hcsouza/fiap-tech-fast-food/assets/19635428/6cbdf605-acd5-4936-8e85-aa077b8c1ff9">

